### PR TITLE
Only redefine ColorColumn if g:docile_color_column is set

### DIFF
--- a/autoload/docile.vim
+++ b/autoload/docile.vim
@@ -1,5 +1,7 @@
 function! docile#createCommands() abort
-  exec "hi ColorColumn ctermbg=" . g:docile_color_column
+  if exists('g:docile_color_column')
+    exec "hi ColorColumn ctermbg=" . g:docile_color_column
+  endif
   command! -buffer -nargs=0 DocileToggle call docile#help#toggleFiletype()
   command! -buffer -nargs=0 DocileHelpGuide call docile#help#toggleGuide()
   command! -buffer -nargs=0 DocileFormatParagraph call docile#help#realign()

--- a/plugin/docile.vim
+++ b/plugin/docile.vim
@@ -10,7 +10,6 @@ endfunction
 
 " Set some defaults
 for [option, default] in items({
-  \   'color_column': 'red',
   \   'ref_column': 50,
   \   'use_plugin_refs': 1,
   \   'toggle_mapping': 'dot',


### PR DESCRIPTION
Currently vim-docile will always redefine the highlight group for the
colocolumn to red unless specified otherwise. This conflicts with other
settings that set the highlight group of `ColorColumn` to another value.

As red is the default color for the colorcolumn anyway and any user
wanting to set it to a different color for vim-docile by defining
`g:docile_color_column` the `ColorColumn` highlight group is not only
modified if explicitly requested by the user.

Note however, that issue
https://github.com/tandrewnichols/vim-docile/issues/1 still applies if
`g:docile_color_column` is set.